### PR TITLE
Add usage of 'neutral' check run state for only warning annotations

### DIFF
--- a/lib/github_bot/github/check_run.rb
+++ b/lib/github_bot/github/check_run.rb
@@ -44,6 +44,11 @@ module GithubBot
         update(status: 'completed', conclusion: 'action_required', completed_at: Time.now, **options)
       end
 
+      # Public: Updates the check run to a neutral state
+      def neutral!(**options)
+        update(status: 'completed', conclusion: 'neutral', completed_at: Time.now, **options)
+      end
+
       private
 
       def update(**options)

--- a/lib/github_bot/github/payload.rb
+++ b/lib/github_bot/github/payload.rb
@@ -67,6 +67,11 @@ module GithubBot
         end
       end
 
+      # Public: Returns the review information for payloads that are of type pull request review
+      def review
+        payload[:review]
+      end
+
       # Public: Returns <true> if the sender is of type 'Bot'; otherwise, <false>
       def sender_type_bot?
         payload[:sender][:type].downcase == 'bot' # rubocop:disable Performance/Casecmp

--- a/lib/github_bot/validator/base.rb
+++ b/lib/github_bot/validator/base.rb
@@ -78,7 +78,8 @@ module GithubBot
               @check.neutral!(
                 output: {
                   title: "#{name} validation is complete...",
-                  summary: "#{name} validation determined there are no required changes; however, please review the warnings as they may impact future changes.",
+                  summary: "#{name} validation determined there are no required changes; however, please review the " \
+                           'warnings as they may impact future changes.',
                   annotations: annotations
                 }
               )

--- a/lib/github_bot/validator/base.rb
+++ b/lib/github_bot/validator/base.rb
@@ -69,14 +69,30 @@ module GithubBot
         else
           # because limitation of 50 checks per API call execution, break up annotations
           # https://developer.github.com/v3/checks/runs/
-          @feedback.each_slice(50).to_a.each do |annotations|
-            @check.action_required!(
-              output: {
-                title: "#{name} validation is complete...",
-                summary: "#{name} validation determined there are changes that need attention.",
-                annotations: annotations
-              }
-            )
+
+          # need to identify if something other than warnings
+          non_warnings = @feedback.select { |h| h[:annotation_level] != 'warning' }
+
+          if non_warnings.empty?
+            @feedback.each_slice(50).to_a.each do |annotations|
+              @check.neutral!(
+                output: {
+                  title: "#{name} validation is complete...",
+                  summary: "#{name} validation determined there are no required changes; however, please review the warnings as they may impact future changes.",
+                  annotations: annotations
+                }
+              )
+            end
+          else
+            @feedback.each_slice(50).to_a.each do |annotations|
+              @check.action_required!(
+                output: {
+                  title: "#{name} validation is complete...",
+                  summary: "#{name} validation determined there are changes that need attention.",
+                  annotations: annotations
+                }
+              )
+            end
           end
         end
       rescue StandardError => e

--- a/lib/github_bot/version.rb
+++ b/lib/github_bot/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module GithubBot
-  VERSION = '0.1.1'
+  VERSION = '0.2.0'
 
   # version module
   module Version

--- a/spec/lib/github_bot/github/check_run_spec.rb
+++ b/spec/lib/github_bot/github/check_run_spec.rb
@@ -54,4 +54,16 @@ RSpec.describe GithubBot::Github::CheckRun do
       subject.action_required!  
     end
   end
+
+  it '#neutral!' do
+    time = Time.iso8601('2020-04-21T00:00:00Z')
+    Timecop.freeze(time) do
+      expect(subject).to receive(:update).with(
+        status: 'completed',
+        conclusion: 'neutral',
+        completed_at: time
+      )
+      subject.neutral!
+    end
+  end
 end

--- a/spec/lib/github_bot/validator/base_spec.rb
+++ b/spec/lib/github_bot/validator/base_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe GithubBot::Validator::Base do
+  let(:client_api) { double }
+  let(:check_run) { double }
+  let(:warning_feedback) {
+    {
+      path: '/foo/bar.rb',
+      annotation_level: 'warning',
+      message: 'this is my warning annotation'
+    }
+  }
+  let(:failure_feedback) {
+    {
+      path: '/bing/baz.rb',
+      annotation_level: 'failure',
+      message: 'this is my failure annotation'
+    }
+  }
+
+  subject { described_class.new }
+
+  before do
+    allow(subject).to receive(:client_api).and_return(client_api)
+  end
+
+  describe '#check_run' do
+    context 'when feedback empty' do
+      it 'completes' do
+        expect(client_api).to receive(:create_check_run).and_return(check_run)
+        expect(check_run).to receive(:complete!)
+        expect { subject.check_run(name: 'foo') }.not_to raise_error
+      end
+    end
+
+    context 'when feedback warnings' do
+      before do
+        subject.instance_variable_set(:@feedback, [warning_feedback])
+      end
+
+      it 'gives a neutral check response' do
+        expect(client_api).to receive(:create_check_run).and_return(check_run)
+        expect(check_run).to receive(:neutral!)
+        expect { subject.check_run(name: 'bar') }.not_to raise_error
+      end
+    end
+
+    context 'when feedback failures' do
+      before do
+        subject.instance_variable_set(:@feedback, [failure_feedback])
+      end
+
+      it 'gives a needs attention response' do
+        expect(client_api).to receive(:create_check_run).and_return(check_run)
+        expect(check_run).to receive(:action_required!)
+        expect { subject.check_run(name: 'baz') }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of Changes
Add usage of 'neutral' check run state for only warning annotations

## Motivation and Context
To allow merging of pull request check runs that only have warnings

## How Has This Been Tested?
specs and local integration

## Type of change
<!--Put an 'x' in all of the boxes that apply.-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Release activity

## Checklist:
<!--Put an 'x' in all of the boxes to assure following guidance.-->
Following the [Contributing Guidelines][3]
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works and they pass when merging upstream
- [x] I have added an entry to the [Changelog][2] accordingly
- [x] I have added my name to the [CONTRIBUTORS.md][1]
- [x] I have [squashed related commits][4]

[1]: ./CONTRIBUTORS.md
[2]: ./CHANGELOG.md
[3]: ./CONTRIBUTING.md
[4]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html